### PR TITLE
Binding cleanup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -235,7 +235,7 @@ const App = class extends EventHandler {
 		this._flatDisplay = null
 		this._debugScene = null // either _portalScene or _immersiveScene
 		this._flatCamera = null // a THREE.Camera
-		this._flatClock = null  // a THREE.Clock
+		this._flatClock = null // a THREE.Clock
 		/* _flatTransformation is used to transform the camera during dev based on input triggered actions */
 		this._flatTransformation = null
 
@@ -280,7 +280,7 @@ const App = class extends EventHandler {
 		window.requestAnimationFrame(this._handleWindowAnimationFrame)
 
 		// Listen for messages from the potassium-inspector WebExtension
-		window.addEventListener("message", this._handleWindowMessage)
+		window.addEventListener('message', this._handleWindowMessage)
 	}
 
 	/** @type {Router} */
@@ -409,16 +409,18 @@ const App = class extends EventHandler {
 			show = this._flatDisplay === null ? true : false
 		}
 		if (show) {
-			if (this._flatDisplay !== null){
-				if(immersive){
-					if(this._debugScene === this._immersiveScene) return
+			if (this._flatDisplay !== null) {
+				if (immersive) {
+					if (this._debugScene === this._immersiveScene) return
 				} else {
-					if(this._debugScene === this._portalScene) return
+					if (this._debugScene === this._portalScene) return
 				}
 				document.body.removeChild(this._flatDisplay.dom)
 				this._flatDisplay.stop()
 			}
-			this._dom.removeClass('flat-mode', 'immersive-mode', 'portal-mode').addClass(immersive ? 'immersive-mode' : 'portal-mode')
+			this._dom
+				.removeClass('flat-mode', 'immersive-mode', 'portal-mode')
+				.addClass(immersive ? 'immersive-mode' : 'portal-mode')
 			this._debugScene = immersive ? this._immersiveScene : this._portalScene
 			this._flatCamera = som.perspectiveCamera([45, 1, 0.5, 10000])
 			this._flatClock = new THREE.Clock(false)
@@ -444,21 +446,28 @@ const App = class extends EventHandler {
 	/**
 	The potassium-inspector sends messages using window.postMessage this method watches for them
 	*/
-	_handleWindowMessage(event){
-		switch(event.data.action){
+	_handleWindowMessage(event) {
+		switch (event.data.action) {
 			case App.GetKSSAction:
 				const rawKSS = this._stylist.stylesheets[0] ? this._stylist.stylesheets[0].raw : ''
-				window.postMessage({
-					action: App.PutKSSAction,
-					kss: rawKSS
-				}, '*')
+				window.postMessage(
+					{
+						action: App.PutKSSAction,
+						kss: rawKSS
+					},
+					'*'
+				)
 				break
 			case App.GetStyleTreeAction:
-				const styleTree = event.data.scene === 'portal' ? this._portalScene.getStyleTree() : this._immersiveScene.getStyleTree()
-				window.postMessage({
-					tree: styleTree,
-					action: App.PutStyleTreeAction
-				}, '*')
+				const styleTree =
+					event.data.scene === 'portal' ? this._portalScene.getStyleTree() : this._immersiveScene.getStyleTree()
+				window.postMessage(
+					{
+						tree: styleTree,
+						action: App.PutStyleTreeAction
+					},
+					'*'
+				)
 				break
 			case App.ShowFlatDisplayAction:
 				app.toggleFlatDisplay(true, event.data.display !== 'portal')
@@ -597,7 +606,8 @@ const App = class extends EventHandler {
 	}
 }
 
-/** Actions for messages between the page and the potassium-inspector WebExtension */ 
+/** Actions for messages between the page and the potassium-inspector WebExtension */
+
 App.GetKSSAction = 'getKSS'
 App.PutKSSAction = 'putKSS'
 App.GetStyleTreeAction = 'getStyleTree'

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -84,7 +84,7 @@ dom.domElementFunction = function(tagName, ...params) {
 	element.addClass = function(...classNames) {
 		const classAttribute = this.getAttribute('class') || ''
 		const classes = classAttribute === '' ? [] : classAttribute.split(/\s+/)
-		for(const className of classNames){
+		for (const className of classNames) {
 			if (classes.indexOf(className) === -1) {
 				classes.push(className)
 			}
@@ -95,7 +95,7 @@ dom.domElementFunction = function(tagName, ...params) {
 	element.removeClass = function(...classNames) {
 		const classAttribute = this.getAttribute('class') || ''
 		const classes = classAttribute === '' ? [] : classAttribute.split(/\s+/)
-		for(const className of classNames){
+		for (const className of classNames) {
 			const index = classes.indexOf(className)
 			if (index !== -1) {
 				classes.splice(index, 1)

--- a/src/DataObject.js
+++ b/src/DataObject.js
@@ -17,7 +17,7 @@ const DataObject = class extends EventHandler {
 	cleanup() {
 		if (this.cleanedUp) return
 		this.cleanedUp = true
-		this.clearListeners()
+		super.cleanup()
 	}
 	/** @type {bool} true until a fetch (even a failed fetch) returns */
 	get isNew() {

--- a/src/EventHandler.js
+++ b/src/EventHandler.js
@@ -71,7 +71,7 @@ const EventHandler = class {
 		return this._listeners
 	}
 
-	clearListeners() {
+	cleanup() {
 		if (typeof this._listeners !== 'undefined') {
 			this._listeners.length = 0
 		}

--- a/src/Router.js
+++ b/src/Router.js
@@ -30,7 +30,7 @@ const Router = class extends EventHandler {
 		if (this.cleanedUp) return
 		this.cleanedUp = true
 		window.removeEventListener('hashchange', this.hashListener)
-		this.clearListeners()
+		super.cleanup()
 	}
 	addRoute(regex, eventName, ...parameters) {
 		this.routes.push(new Route(regex, eventName, ...parameters))

--- a/src/ThreeAdditions.js
+++ b/src/ThreeAdditions.js
@@ -102,6 +102,16 @@ THREE.Object3D.prototype.getObjectsBySelector = function(selector) {
 }
 
 /**
+@param {string} selector like 'node[name=ModeSwitcherComponent] .button-component > text'
+@return {Object3D?} the first node to match the selector or null if none were found
+*/
+THREE.Object3D.prototype.querySelector = function(selector) {
+	const results = THREE.Object3D.prototype.getObjectsBySelector(selector)
+	if (results.length > 0) return results[0]
+	return null
+}
+
+/**
 logs to the console the computed styles for a node and its descendents
 @param {THREE.Object3D} node
 @param {int} [tabDepth=0]
@@ -112,25 +122,45 @@ THREE.Object3D.prototype.logStyles = function(node = this, tabDepth = 0, showVar
 	this._getStyleTreeLines(node, [], tabDepth, showVars, localsOnly).forEach(line => console.log(line))
 }
 
-THREE.Object3D.prototype.getStyleTree = function(node = this, tabDepth = 0, showVars = false, localsOnly = false){
+THREE.Object3D.prototype.getStyleTree = function(node = this, tabDepth = 0, showVars = false, localsOnly = false) {
 	return this._getStyleTreeLines(node, [], tabDepth, showVars, localsOnly).join('\n')
 }
 
-THREE.Object3D.prototype._getStyleTreeLines = function(node = this, results = [], tabDepth = 0, showVars = false, localsOnly = false){
+THREE.Object3D.prototype._getStyleTreeLines = function(
+	node = this,
+	results = [],
+	tabDepth = 0,
+	showVars = false,
+	localsOnly = false
+) {
 	const tabs = _generateTabs(tabDepth)
-	results.push(tabs + '> ' + (node.name || 'unnamed') + ': ' + node.getClasses().map(clazz => `.${clazz}`).join('') + (node.layoutIsDirty ? '\tdirty' : ''))
+	results.push(
+		tabs +
+			'> ' +
+			(node.name || 'unnamed') +
+			': ' +
+			node
+				.getClasses()
+				.map(clazz => `.${clazz}`)
+				.join('') +
+			(node.layoutIsDirty ? '\tdirty' : '')
+	)
 	if (localsOnly) {
 		for (const styleInfo of node.localStyles) {
 			if (showVars === false && styleInfo.property.startsWith('--')) continue
-			reults.push(tabs + '\t' + styleInfo.property + ': ' + styleInfo.value + (styleInfo.important ? ' !important' : ''))
+			reults.push(
+				tabs + '\t' + styleInfo.property + ': ' + styleInfo.value + (styleInfo.important ? ' !important' : '')
+			)
 		}
 	} else {
 		for (const styleInfo of node.computedStyles) {
 			if (showVars === false && styleInfo.property.startsWith('--')) continue
-			results.push(tabs + '\t' + styleInfo.property + ': ' + styleInfo.value + (styleInfo.important ? ' !important' : ''))
+			results.push(
+				tabs + '\t' + styleInfo.property + ': ' + styleInfo.value + (styleInfo.important ? ' !important' : '')
+			)
 		}
 	}
-	for (const child of node.children){
+	for (const child of node.children) {
 		this._getStyleTreeLines(child, results, tabDepth + 1, showVars, localsOnly)
 	}
 	return results

--- a/src/style/Declaration.js
+++ b/src/style/Declaration.js
@@ -28,7 +28,7 @@ class Declaration {
 	}
 
 	/** @return {string} */
-	get raw(){
+	get raw() {
 		return `${this.property}: ${this.value};`
 	}
 

--- a/src/style/Selector.js
+++ b/src/style/Selector.js
@@ -37,8 +37,11 @@ class SelectorFragmentList {
 		}
 	}
 
-	get raw(){
-		return Array.from(this).filter(frag => frag.type !== Combinator.DESCENDANT).map(frag => frag.raw).join(' ')
+	get raw() {
+		return Array.from(this)
+			.filter(frag => frag.type !== Combinator.DESCENDANT)
+			.map(frag => frag.raw)
+			.join(' ')
 	}
 
 	/**

--- a/src/style/Stylesheet.js
+++ b/src/style/Stylesheet.js
@@ -34,14 +34,14 @@ class Stylesheet {
 		return this._data
 	}
 
-	get raw(){
+	get raw() {
 		return this._data.rules.map(rule => this.rawRule(rule)).join('\n\n')
 	}
 
 	/**
 	Log to console a human readable dump of this stylesheet
 	*/
-	prettyPrint(){
+	prettyPrint() {
 		this._data.rules.forEach(rule => console.log(this.rawRule(rule)))
 	}
 
@@ -94,9 +94,13 @@ class Stylesheet {
 	}
 
 	/** @return {string} the raw KSS for a rule */
-	rawRule(rule){
-		const selector = Array.from(rule.selectors).map(selector => selector.raw).join(',\n')
-		const declarations = Array.from(rule.declarations).map(declaration => `\t${declaration.raw}`).join('\n')
+	rawRule(rule) {
+		const selector = Array.from(rule.selectors)
+			.map(selector => selector.raw)
+			.join(',\n')
+		const declarations = Array.from(rule.declarations)
+			.map(declaration => `\t${declaration.raw}`)
+			.join('\n')
 		return `${selector} \{\n${declarations}\n\}`
 	}
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -326,12 +326,12 @@ tests.push(
 			constructor(dataObject, options) {
 				super(dataObject, options)
 				this.fooDOM = dom.div().appendTo(this.flatDOM)
-				this.bindTextDOM('foo', this.fooDOM)
+				this.bindText('foo', this.fooDOM)
 				this.burfDOM = dom.div().appendTo(this.flatDOM)
-				this.bindTextDOM('burf', this.burfDOM, value => {
+				this.bindText('burf', this.burfDOM, value => {
 					return (value ? value : 'nothing') + ' and more!'
 				})
-				this.bindAttributeDOM('blart', this.flatDOM, 'bluez')
+				this.bindAttribute('blart', this.flatDOM, 'bluez')
 			}
 		}
 


### PR DESCRIPTION
Refactored and renamed the data binding functionality in Component to be more consistent across DOM and SOM per Issue #2 

Cleaned up the som.text method to remove unnecessary sub-groups.

Added Object3D.querySelector which works like HTMLElement.querySelector.
Prettier.