### PR TITLE
Fix touch input for WebXR Viewer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -619,17 +619,7 @@ const App = class extends EventHandler {
 		this._pickingInputSource.clearIntersectObjects()
 		this._actionManager.queryInputPath('/input/touch/normalized-position/0', _workingQueryArray)
 		if (_workingQueryArray[0]) {
-			this._pickingInputSource.touch = this._portalEngine.pickScreen(
-				_workingQueryArray[1][0],
-				_workingQueryArray[1][1]
-			)
-			console.log('touched',
-				_workingQueryArray[1][0],
-				_workingQueryArray[1][1]
-			)
-			if(this._pickingInputSource.touch){
-				console.log('Hit', this._pickingInputSource.touch)
-			}
+			this._pickingInputSource.touch = this._portalEngine.pickScreen(_workingQueryArray[1][0], _workingQueryArray[1][1])
 		}
 
 		// Update actions

--- a/src/App.js
+++ b/src/App.js
@@ -617,13 +617,19 @@ const App = class extends EventHandler {
 	_handlePortalTick() {
 		// Update picking
 		this._pickingInputSource.clearIntersectObjects()
-		this._actionManager.queryInputPath('/input/touch/normalized-position', _workingQueryArray)
+		this._actionManager.queryInputPath('/input/touch/normalized-position/0', _workingQueryArray)
 		if (_workingQueryArray[0]) {
 			this._pickingInputSource.touch = this._portalEngine.pickScreen(
-				_workingQueryArray[1][0][0],
-				_workingQueryArray[1][0][1],
-				_workingQueryArray[1][0][2]
+				_workingQueryArray[1][0],
+				_workingQueryArray[1][1]
 			)
+			console.log('touched',
+				_workingQueryArray[1][0],
+				_workingQueryArray[1][1]
+			)
+			if(this._pickingInputSource.touch){
+				console.log('Hit', this._pickingInputSource.touch)
+			}
 		}
 
 		// Update actions

--- a/src/display/Engine.js
+++ b/src/display/Engine.js
@@ -86,16 +86,13 @@ const Engine = class extends EventHandler {
 	}
 
 	pickScreen(normalizedMouseX, normalizedMouseY) {
-		this._raycaster.setFromCamera(
-			{
-				x: normalizedMouseX,
-				y: normalizedMouseY
-			},
-			this._camera
-		)
-		const intersects = this._raycaster.intersectObjects(this._scene.children, true)
-		if (intersects.length === 0) return null
-		return intersects[0]
+		_workingVector2_1.x = normalizedMouseX
+		_workingVector2_1.y = normalizedMouseY
+		this._raycaster.setFromCamera(_workingVector2_1, this._camera)
+		_workingPickResults.splice(0, _workingPickResults.length)
+		this._raycaster.intersectObjects(this._scene.children, true, _workingPickResults)
+		if (_workingPickResults.length === 0) return null
+		return _workingPickResults[0]
 	}
 
 	pickPose(pointObject3D) {
@@ -103,9 +100,10 @@ const Engine = class extends EventHandler {
 		pointObject3D.getWorldQuaternion(this._workingQuat)
 		this._raycaster.ray.direction.set(0, 0, -1).applyQuaternion(this._workingQuat)
 		this._raycaster.ray.direction.normalize()
-		const intersects = this._raycaster.intersectObjects(this._scene.children, true)
-		if (intersects.length === 0) return null
-		return intersects[0]
+		_workingPickResults.splice(0, _workingPickResults.length)
+		this._raycaster.intersectObjects(this._scene.children, true, _workingPickResults)
+		if (_workingPickResults.length === 0) return null
+		return _workingPickResults[0]
 	}
 
 	/**
@@ -203,6 +201,9 @@ const Engine = class extends EventHandler {
 		}
 	}
 }
+
+let _workingVector2_1 = new THREE.Vector2()
+let _workingPickResults = new Array()
 
 Engine.STARTED = 'engine-started'
 Engine.STOPPED = 'engine-stopped'

--- a/src/display/FlatDisplay.js
+++ b/src/display/FlatDisplay.js
@@ -77,7 +77,7 @@ const FlatDisplay = class extends SceneDisplay {
 	_updateSize() {
 		this._width = this.dom.clientWidth
 		this._height = this.dom.clientHeight
-		this._renderer.setPixelRatio(window.devicePixelRatio)
+		this._renderer.setPixelRatio(1)
 		this._camera.aspect = this._width / this._height
 		this._camera.updateProjectionMatrix()
 		this._renderer.setSize(this._width, this._height, false)

--- a/src/display/WebXRViewerDisplay.js
+++ b/src/display/WebXRViewerDisplay.js
@@ -49,6 +49,7 @@ class WebXRViewerDisplay extends SceneDisplay {
 		})
 		this._renderer.autoClear = false
 		this._renderer.setPixelRatio(window.devicePixelRatio)
+		this._renderer.setSize(document.documentElement.offsetWidth, document.documentElement.offsetHeight, true)
 	}
 
 	get blendMode() {
@@ -130,8 +131,8 @@ class WebXRViewerDisplay extends SceneDisplay {
 			_workingViewport = this._xrSession.baseLayer.getViewport(_workingView)
 
 			this._camera.matrix.fromArray(_workingPose.getViewMatrix(_workingView))
-			this._camera.updateMatrixWorld()
 			this._camera.projectionMatrix.fromArray(_workingView.projectionMatrix)
+			this._camera.updateMatrixWorld()
 
 			this._renderer.setViewport(
 				_workingViewport.x,

--- a/src/display/WebXRViewerDisplay.js
+++ b/src/display/WebXRViewerDisplay.js
@@ -14,8 +14,6 @@ class WebXRViewerDisplay extends SceneDisplay {
 		this._eyeLevelFrameOfReference = null
 
 		this._outputCanvas = document.createElement('canvas')
-		this._outputCanvas.width = document.documentElement.offsetWidth
-		this._outputCanvas.height = document.documentElement.offsetHeight
 		this._outputCanvas.setAttribute('class', 'xr-canvas')
 		this._outputContext = this._outputCanvas.getContext('xrpresent')
 		if (!this._outputContext) {
@@ -23,8 +21,6 @@ class WebXRViewerDisplay extends SceneDisplay {
 		}
 
 		this._glCanvas = document.createElement('canvas')
-		this._glCanvas.width = document.documentElement.offsetWidth
-		this._glCanvas.height = document.documentElement.offsetHeight
 		this._glCanvas.setAttribute('class', 'xr-canvas')
 		this._glContext = this._glCanvas.getContext('webgl', {
 			compatibleXRDevice: this._xrDevice
@@ -48,8 +44,8 @@ class WebXRViewerDisplay extends SceneDisplay {
 			alpha: false
 		})
 		this._renderer.autoClear = false
-		this._renderer.setPixelRatio(window.devicePixelRatio)
-		this._renderer.setSize(document.documentElement.offsetWidth, document.documentElement.offsetHeight, true)
+		this._renderer.setPixelRatio(1)
+		this._resize()
 	}
 
 	get blendMode() {
@@ -72,6 +68,11 @@ class WebXRViewerDisplay extends SceneDisplay {
 			document.body.style['background-color'] = 'rgba(0, 0, 0, 0)'
 
 			this._dom.appendChild(this._outputCanvas)
+
+			this._outputCanvas.width = document.documentElement.offsetWidth
+			this._outputCanvas.height = document.documentElement.offsetHeight
+			this._glCanvas.width = document.documentElement.offsetWidth
+			this._glCanvas.height = document.documentElement.offsetHeight
 
 			this._xrDevice
 				.requestSession({ outputContext: this._outputContext })
@@ -112,12 +113,29 @@ class WebXRViewerDisplay extends SceneDisplay {
 		return Promise.resolve()
 	}
 
+	_resize() {
+		const w = document.body.clientWidth
+		const h = document.body.clientHeight
+		this._renderer.setSize(w, h, true)
+		this._outputCanvas.width = w
+		this._outputCanvas.height = h
+		this._glCanvas.width = w
+		this._glCanvas.height = h
+	}
+
 	_render(t, frame) {
 		if (this._isStarted === false || this._xrSession === null || this._xrSession.ended) return
 		this._xrSession.requestAnimationFrame(this._render)
 
 		if (this._tickCallback) {
 			this._tickCallback()
+		}
+
+		if (
+			document.documentElement.offsetHeight != this._glCanvas.height ||
+			document.documentElement.offsetWidth != this._glCanvas.width
+		) {
+			this._resize()
 		}
 
 		this._renderer.clear()

--- a/styles/potassium-es.kss
+++ b/styles/potassium-es.kss
@@ -13,8 +13,10 @@ html,
 .xr-canvas,
 .arkit-device-wrapper, 
 .arkit-device-wrapper canvas {
-	width: 100%;
-	height: 100%;
+	width: 100vw;
+	height: 100vh;
+	max-width: 100vw;
+	max-height: 100vh;
 	background: inherit;
 }
 


### PR DESCRIPTION
The main problem was that the window.pixelRatio was non-zero and the renderer was set up to use that. Because of that, the Three.Raycaster.setFromCamera method was incorrectly calculating where normalized touch coordinates lay in the view.